### PR TITLE
Truncate long queries in tooltips

### DIFF
--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import ClippedBox from 'sentry/components/clippedBox';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
@@ -64,18 +65,28 @@ export function FullSpanDescription({
         stringifiedQuery = description || fullSpan?.sentry_tags?.description || 'N/A';
       }
 
-      return <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>;
+      return (
+        <ClippedBox clipHeight={200} btnText="View Full Query">
+          <CodeSnippet language="json">{stringifiedQuery}</CodeSnippet>
+        </ClippedBox>
+      );
     }
 
     return (
-      <CodeSnippet language="sql">
-        {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
-      </CodeSnippet>
+      <ClippedBox clipHeight={200} btnText="View Full Query">
+        <CodeSnippet language="sql">
+          {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
+        </CodeSnippet>
+      </ClippedBox>
     );
   }
 
   if (moduleName === ModuleName.RESOURCE) {
-    return <CodeSnippet language="http">{description}</CodeSnippet>;
+    return (
+      <ClippedBox clipHeight={200} btnText="View Full URL">
+        <CodeSnippet language="http">{description}</CodeSnippet>
+      </ClippedBox>
+    );
   }
 
   return <Fragment>{description}</Fragment>;

--- a/static/app/views/insights/common/components/spanDescription.tsx
+++ b/static/app/views/insights/common/components/spanDescription.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import ClippedBox from 'sentry/components/clippedBox';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {space} from 'sentry/styles/space';
@@ -103,9 +104,11 @@ export function DatabaseSpanDescription({
           <LoadingIndicator mini />
         </WithPadding>
       ) : (
-        <CodeSnippet language={system === 'mongodb' ? 'json' : 'sql'} isRounded={false}>
-          {formattedDescription ?? ''}
-        </CodeSnippet>
+        <ClippedBox clipHeight={300} btnText="View Full Query">
+          <CodeSnippet language={system === 'mongodb' ? 'json' : 'sql'} isRounded={false}>
+            {formattedDescription ?? ''}
+          </CodeSnippet>
+        </ClippedBox>
       )}
 
       {!areIndexedSpansLoading && !isRawSpanLoading && (


### PR DESCRIPTION
<!-- Describe your PR here. -->
Truncates long queries and URLs in tooltips and span descriptions using `ClippedBox` to improve readability and prevent excessively large tooltips.

This PR wraps the query/URL display in `FullSpanDescription` (for tooltips) and `DatabaseSpanDescription` (for page display) with `ClippedBox`. This provides:
*   Automatic truncation for content exceeding a set height (200px for tooltips, 300px for page display).
*   A "View Full Query" or "View Full URL" button to expand the content.
*   A consistent user experience for handling long query/URL displays.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-fee42ba5-d898-4763-9e80-8521beee756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fee42ba5-d898-4763-9e80-8521beee756d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

